### PR TITLE
Slug build without bind mount

### DIFF
--- a/lib/qtc/cli/mar/commands.rb
+++ b/lib/qtc/cli/mar/commands.rb
@@ -193,6 +193,7 @@ command 'mar local:run' do |c|
   c.syntax = 'qtc-cli mar local:run'
   c.option '--clean', String, 'Force clean build'
   c.option '--stack STRING', String, 'Define used stack (default: cedar-14)'
+  c.option '--branch STRING', String, 'Define used git branch (default: master)'
   c.description = 'Debug mar app locally (requires docker)'
   c.action do |args, options|
     Qtc::Cli::Mar::Debug.new.local_debug(args, options)
@@ -202,6 +203,7 @@ end
 command 'mar local:build_slug' do |c|
   c.syntax = 'qtc-cli mar local:build_slug'
   c.option '--stack STRING', String, 'Define used stack (default: cedar-14)'
+  c.option '--branch STRING', String, 'Define used git branch (default: master)'
   c.description = 'Build mar app slug locally (requires docker)'
   c.action do |args, options|
     Qtc::Cli::Mar::Debug.new.local_build_slug(options)


### PR DESCRIPTION
This PR improves local slug build so that slugbuilder does not need bind mounted git repository. It also adds new option "--branch" that defaults to "master".